### PR TITLE
KP-640 [Github] method Create New Repository error message for insufficient credentials is unhelpful "Not Found"

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -1,0 +1,7 @@
+const CREATE_REPO_FAILED_MESSAGE = "Github only returned error \"Not Found\". Perhaps your access token provides insufficient access? The required scope to create a new repository is \"repo\" (full control of private repositories).";
+const CREATE_ORG_WEBHOOK_FAILED_MESSAGE = "Github only returned error \"Not Found\". Perhaps your access token provides insufficient access? The required scope to create an organization webhook is \"admin:org_hook\" (full control of organization hooks).";
+
+module.exports = {
+  CREATE_REPO_FAILED_MESSAGE,
+  CREATE_ORG_WEBHOOK_FAILED_MESSAGE,
+};

--- a/consts.js
+++ b/consts.js
@@ -1,7 +1,7 @@
-const CREATE_REPO_FAILED_MESSAGE = "Github only returned error \"Not Found\". Perhaps your access token provides insufficient access? The required scope to create a new repository is \"repo\" (full control of private repositories).";
-const CREATE_ORG_WEBHOOK_FAILED_MESSAGE = "Github only returned error \"Not Found\". Perhaps your access token provides insufficient access? The required scope to create an organization webhook is \"admin:org_hook\" (full control of organization hooks).";
+const CREATE_REPO_NOT_FOUND_ERROR_MESSAGE = "Github returned error \"Not Found\" only. Perhaps your access token provides insufficient access. The required scope to create a new repository is \"repo\" (full control of private repositories).";
+const CREATE_ORG_WEBHOOK_NOT_FOUND_ERROR_MESSAGE = "Github returned error \"Not Found\" only. Perhaps your access token provides insufficient access. The required scope to create an organization webhook is \"admin:org_hook\" (full control of organization hooks).";
 
 module.exports = {
-  CREATE_REPO_FAILED_MESSAGE,
-  CREATE_ORG_WEBHOOK_FAILED_MESSAGE,
+  CREATE_REPO_NOT_FOUND_ERROR_MESSAGE,
+  CREATE_ORG_WEBHOOK_NOT_FOUND_ERROR_MESSAGE,
 };

--- a/github.service.js
+++ b/github.service.js
@@ -1,4 +1,7 @@
-const { sendToGithub, listGithubRequest, getRepo } = require("./helpers");
+const { CREATE_REPO_FAILED_MESSAGE, CREATE_ORG_WEBHOOK_FAILED_MESSAGE } = require("./consts");
+const {
+  sendToGithub, listGithubRequest, getRepo, handleGithubNotFoundError,
+} = require("./helpers");
 const parsers = require("./parsers");
 
 async function sendStatus(action, settings) {
@@ -44,7 +47,7 @@ async function createRepo(action, settings) {
     description: parsers.string(description),
   };
 
-  return sendToGithub(reqPath, "POST", token, body);
+  return sendToGithub(reqPath, "POST", token, body).catch(handleGithubNotFoundError(CREATE_REPO_FAILED_MESSAGE));
 }
 
 async function createRepoFromTemplate(action, settings) {
@@ -123,7 +126,7 @@ async function createOrganizationWebhook(action, settings) {
     active: !parsers.boolean(notActive),
   };
 
-  return sendToGithub(reqPath, "POST", token, body);
+  return sendToGithub(reqPath, "POST", token, body).catch(handleGithubNotFoundError(CREATE_ORG_WEBHOOK_FAILED_MESSAGE));
 }
 
 async function setBranchProtectionRule(action, settings) {

--- a/github.service.js
+++ b/github.service.js
@@ -1,6 +1,6 @@
-const { CREATE_REPO_FAILED_MESSAGE, CREATE_ORG_WEBHOOK_FAILED_MESSAGE } = require("./consts");
+const { CREATE_REPO_NOT_FOUND_ERROR_MESSAGE, CREATE_ORG_WEBHOOK_NOT_FOUND_ERROR_MESSAGE } = require("./consts");
 const {
-  sendToGithub, listGithubRequest, getRepo, handleGithubNotFoundError,
+  sendToGithub, listGithubRequest, getRepo, parseAndHandleGithubError,
 } = require("./helpers");
 const parsers = require("./parsers");
 
@@ -47,7 +47,9 @@ async function createRepo(action, settings) {
     description: parsers.string(description),
   };
 
-  return sendToGithub(reqPath, "POST", token, body).catch(handleGithubNotFoundError(CREATE_REPO_FAILED_MESSAGE));
+  return sendToGithub(reqPath, "POST", token, body).catch(
+    parseAndHandleGithubError(CREATE_REPO_NOT_FOUND_ERROR_MESSAGE),
+  );
 }
 
 async function createRepoFromTemplate(action, settings) {
@@ -133,7 +135,7 @@ async function createOrganizationWebhook(action, settings) {
   };
 
   const webhookResult = await sendToGithub(reqPath, "POST", token, body).catch(
-    handleGithubNotFoundError(CREATE_ORG_WEBHOOK_FAILED_MESSAGE),
+    parseAndHandleGithubError(CREATE_ORG_WEBHOOK_NOT_FOUND_ERROR_MESSAGE),
   );
   if (!body.active) {
     await updateOrganizationWebhook({

--- a/helpers.js
+++ b/helpers.js
@@ -70,7 +70,7 @@ function getRepo(params) {
   return repo;
 }
 
-function handleGithubNotFoundError(errorMessage) {
+function parseAndHandleGithubError(errorMessage) {
   return (error) => {
     throw error.message === "Not Found" ? new Error(errorMessage) : error;
   };
@@ -82,5 +82,5 @@ module.exports = {
   removeEmptyFieldsRecursive,
   stripAction,
   getRepo,
-  handleGithubNotFoundError,
+  parseAndHandleGithubError,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -70,10 +70,17 @@ function getRepo(params) {
   return repo;
 }
 
+function handleGithubNotFoundError(errorMessage) {
+  return (error) => {
+    throw error.message === "Not Found" ? new Error(errorMessage) : error;
+  };
+}
+
 module.exports = {
   sendToGithub,
   listGithubRequest,
   removeEmptyFieldsRecursive,
   stripAction,
   getRepo,
+  handleGithubNotFoundError,
 };


### PR DESCRIPTION
Add informative error messages for 404 GitHub errors when creating the organization webhook or creating new repo.

[**KP-640 in JIRA**](https://kaholo.atlassian.net/jira/software/c/projects/KP/boards/26?modal=detail&selectedIssue=KP-640)